### PR TITLE
Update speedtest.py

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -2,21 +2,24 @@ import re
 import os
 import subprocess
 from datetime import datetime
-from influxdb import InfluxDBClient
+from influxdb_client import InfluxDBClient, Point, WritePrecision
 import logging
+from typing import Optional, Dict
+from influxdb_client.client.write_api import SYNCHRONOUS
+
 
 # Configure logging
-logging.basicConfig(filename='internet_speed.log', level=logging.INFO)
+logging.basicConfig(filename='internet_speed.log', level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
 
-def run_speed_test(interface):
+def run_speed_test(interface: str) -> Optional[str]:
     try:
         result = subprocess.run(['/usr/bin/speedtest', '--accept-license', '--accept-gdpr', '--interface', interface], capture_output=True, text=True)
         return result.stdout
     except subprocess.CalledProcessError as e:
-        logging.error(f"Error running speedtest: {e}")
+        logging.error(f"Error running speedtest: {e=}")
         return None
 
-def parse_speed_test_output(output):
+def parse_speed_test_output(output: str) -> Optional[Dict[str, float]]:
     ping = re.search('Latency:\s+(.*?)\s', output, re.MULTILINE)
     download = re.search('Download:\s+(.*?)\s', output, re.MULTILINE)
     upload = re.search('Upload:\s+(.*?)\s', output, re.MULTILINE)
@@ -33,13 +36,16 @@ def parse_speed_test_output(output):
         logging.error("Failed to parse speedtest output")
         return None
 
+client = InfluxDBClient(url='http://localhost:8086', token=f'{os.environ["INFLUXDB_USERNAME"]}:{os.environ["INFLUXDB_PASSWORD"]}', org='-') # update as needed
+
 def write_speed_data(speed_data):
     try:
-        client = InfluxDBClient('localhost', 8086, os.environ['INFLUXDB_USERNAME'], os.environ['INFLUXDB_PASSWORD'], 'internetspeed')
-        client.write_points(speed_data)
+        logging.info(f"Attempting to write the following data to InfluxDB: {speed_data}")  # Additional logging
+        with client.write_api(write_options=SYNCHRONOUS) as write_api:
+            write_api.write('internetspeed', org='-', record=speed_data)
         logging.info("Speed data written to InfluxDB successfully.")
     except Exception as e:
-        logging.error(f"Error writing speed data to InfluxDB: {e}")
+        logging.error(f"Error writing speed data to InfluxDB: {e=}")
 
 def main():
     interfaces = ["eth0", "wlan0"]  # List of interfaces to test
@@ -48,17 +54,23 @@ def main():
         output = run_speed_test(interface)
         if output:
             speed_data = parse_speed_test_output(output)
-            if speed_data:
-                speed_data = [{
-                    "measurement": "internet_speed",
-                    "tags": {
-                        "host": "raspberrypi",
-                        "interface": interface
-                    },
-                    "time": datetime.utcnow().isoformat(),
-                    "fields": speed_data
-                }]
-                write_speed_data(speed_data)
+            if speed_data is None:  # If parsing fails
+                speed_data = {
+                    "ping": -1.0,
+                    "download": -1.0,
+                    "upload": -1.0,
+                    "jitter": -1.0
+                }
+        else:  # If running speedtest fails
+            speed_data = {
+                "ping": -1.0,
+                "download": -1.0,
+                "upload": -1.0,
+                "jitter": -1.0
+            }
+
+        data_point = Point("internet_speed").tag("host", "raspberrypi").tag("interface", interface).time(datetime.utcnow(), WritePrecision.NS).field("ping", speed_data["ping"]).field("download", speed_data["download"]).field("upload", speed_data["upload"]).field("jitter", speed_data["jitter"])
+        write_speed_data(data_point)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Downloaded influxdb client for Python. I am creating a new client connection for every write operation which is inefficient. By downloading the influxdb-client for Python, the client connects once and stays connected allowing it to parse data easier with less resources. This stops the skipped crontab jobs and stops the issues from occurring with Grafana and timing of updating the charts. 